### PR TITLE
[JENKINS-38562] Added DSL support for nexus-artifact-uploader-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>credentials</artifactId>
             <version>2.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>job-dsl</artifactId>
+            <version>1.41</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/sp/sd/nexusartifactuploader/dsl/NexusArtifactUploaderJobDslContext.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/dsl/NexusArtifactUploaderJobDslContext.java
@@ -1,0 +1,64 @@
+package sp.sd.nexusartifactuploader.dsl;
+
+import javaposse.jobdsl.dsl.Context;
+
+/**
+ * Created by suresh on 9/29/2016.
+ */
+public class NexusArtifactUploaderJobDslContext implements Context {
+    String protocol;
+    String nexusUrl;
+    String groupId;
+    String artifactId;
+    String version;
+    String packaging;
+    String type;
+    String classifier;
+    String repository;
+    String file;
+    String credentialsId;
+
+    void protocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    void nexusUrl(String nexusUrl) {
+        this.nexusUrl = nexusUrl;
+    }
+
+    void groupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    void artifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    void version(String version) {
+        this.version = version;
+    }
+
+    void packaging(String packaging) {
+        this.packaging = packaging;
+    }
+
+    void type(String type) {
+        this.type = type;
+    }
+
+    void classifier(String classifier) {
+        this.classifier = classifier;
+    }
+
+    void repository(String repository) {
+        this.repository = repository;
+    }
+
+    void file(String file) {
+        this.file = file;
+    }
+
+    void credentialsId(String credentialsId) {
+        this.credentialsId = credentialsId;
+    }
+}

--- a/src/main/java/sp/sd/nexusartifactuploader/dsl/NexusArtifactUploaderJobDslExtension.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/dsl/NexusArtifactUploaderJobDslExtension.java
@@ -1,0 +1,48 @@
+package sp.sd.nexusartifactuploader.dsl;
+
+import hudson.Extension;
+import javaposse.jobdsl.dsl.RequiresPlugin;
+import javaposse.jobdsl.dsl.helpers.step.StepContext;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+import javaposse.jobdsl.plugin.DslExtensionMethod;
+import sp.sd.nexusartifactuploader.NexusArtifactUploader;
+
+/**
+ * Created by suresh on 9/29/2016.
+ */
+
+/*
+```
+ For example:
+ ```
+    freeStyleJob('NexusArtifactUploaderJob') {
+        steps {
+          nexusArtifactUploader {
+            protocol('http')
+            nexusUrl('localhost:8080/nexus')
+            groupId('sp.sd')
+            artifactId('nexus-artifact-uploader')
+            version('2.4')
+            packaging('hpi')
+            type('jar')
+            classifier('debug')
+            repository('NexusArtifactUploader')
+            file('nexus-artifact-uploader.hpi')
+            credentialsId('44620c50-1589-4617-a677-7563985e46e1')
+          }
+        }
+    }
+*/
+
+@Extension(optional = true)
+public class NexusArtifactUploaderJobDslExtension extends ContextExtensionPoint {
+
+    @RequiresPlugin(id = "nexus-artifact-uploader", minimumVersion = "2.3")
+    @DslExtensionMethod(context = StepContext.class)
+    public Object nexusArtifactUploader(Runnable closure) {
+        NexusArtifactUploaderJobDslContext context = new NexusArtifactUploaderJobDslContext();
+        executeInContext(closure, context);
+
+        return new NexusArtifactUploader(context.protocol, context.nexusUrl, null, null, context.groupId, context.artifactId, context.version, context.packaging, context.type, context.classifier, context.repository, context.file, context.credentialsId);
+    }
+}


### PR DESCRIPTION
DSL support added for this plugin below is the script

```
freeStyleJob('NexusArtifactUploaderJob') {
        steps {
          nexusArtifactUploader {
            protocol('http')
            nexusUrl('localhost:8080/nexus')
            groupId('sp.sd')
            artifactId('nexus-artifact-uploader')
            version('2.4')
            packaging('hpi')
            type('jar')
            classifier('debug')
            repository('NexusArtifactUploader')
            file('nexus-artifact-uploader.hpi')
            credentialsId('44620c50-1589-4617-a677-7563985e46e1')
          }
        }
    }
```