### PR TITLE
If no artifacts specified in GUI, fail with specific exception, not NPE

### DIFF
--- a/src/main/java/sp/sd/nexusartifactuploader/NexusArtifactUploader.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/NexusArtifactUploader.java
@@ -141,6 +141,9 @@ public class NexusArtifactUploader extends Builder implements SimpleBuildStep, S
         boolean result = false;
         EnvVars envVars = build.getEnvironment(listener);
         Item project = build.getParent();
+        if (artifacts == null || artifacts.size() == 0) {
+            throw new IOException("No artifacts defined. Artifacts must be defined in addition to group id. See https://plugins.jenkins.io/nexus-artifact-uploader");
+        }
         for (Artifact artifact : artifacts) {
             FilePath artifactFilePath = new FilePath(workspace, build.getEnvironment(listener).expand(artifact.getFile()));
             if (!artifactFilePath.exists()) {


### PR DESCRIPTION
When no artifacts are specified, the build fails with this message

```
ERROR: Build step failed with exception
java.lang.NullPointerException
	at sp.sd.nexusartifactuploader.NexusArtifactUploader.perform(NexusArtifactUploader.java:144)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
...
Build step 'Nexus artifact uploader' marked build as failure
Skipped archiving because build is not successful
```

Add a specific exception message to indicate artifacts must be supplied.