### PR TITLE
Add Pom File option to Artifact.  This adds dependency information to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Uploading snapshots is not supported by this plugin.
                 type('jar')
                 classifier('debug')
                 file('nexus-artifact-uploader.jar')
+                pomFile('pom.xml')
             }
             artifact {
                 artifactId('nexus-artifact-uploader')
@@ -48,6 +49,7 @@ Uploading snapshots is not supported by this plugin.
             [artifactId: projectName,
              classifier: '',
              file: 'my-service-' + version + '.jar',
+             pomFile: 'pom.xml'
              type: 'jar']
         ]
      )

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>sp.sd</groupId>
     <artifactId>nexus-artifact-uploader</artifactId>
-    <version>2.11-SNAPSHOT</version>
+    <version>2.12-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <properties>

--- a/src/main/java/sp/sd/nexusartifactuploader/Artifact.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/Artifact.java
@@ -20,13 +20,15 @@ public class Artifact extends AbstractDescribableImpl<Artifact> implements Seria
     private final String type;
     private final String classifier;
     private final String file;
+    private final String pomFile;
 
     @DataBoundConstructor
-    public Artifact(String artifactId, String type, String classifier, String file) {
+    public Artifact(String artifactId, String type, String classifier, String file, String pomFile) {
         this.artifactId = artifactId;
         this.type = type;
         this.classifier = classifier;
         this.file = file != null ? file.trim() : null;
+        this.pomFile = pomFile != null ? pomFile.trim() : null;
     }
 
     public String getArtifactId() {
@@ -43,6 +45,10 @@ public class Artifact extends AbstractDescribableImpl<Artifact> implements Seria
 
     public String getFile() {
         return file;
+    }
+
+    public String getPomFile() {
+        return pomFile;
     }
 
     @Extension
@@ -77,5 +83,10 @@ public class Artifact extends AbstractDescribableImpl<Artifact> implements Seria
             }
             return FormValidation.ok();
         }
+
+        public FormValidation doCheckPomFile(@QueryParameter String value) {
+            return FormValidation.ok();
+        }
+
     }
 }

--- a/src/main/java/sp/sd/nexusartifactuploader/ArtifactRepositoryManager.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/ArtifactRepositoryManager.java
@@ -52,13 +52,16 @@ public class ArtifactRepositoryManager {
                 .setAuthentication(new Authentication(this.username, this.password));
     }
 
-    public void upload(String groupId, String artifactId, String version,
-                       File artifactFile, String type, String classifier)
-            throws Exception {
+    public void upload(String groupId, String artifactId, String version, File artifactFile, String type, String classifier, File pomFile) throws Exception {
+
         RemoteRepository remoteRepository = makeRemoteRepository();
-        Artifact artifact = new DefaultArtifact(groupId, artifactId, classifier,
-                type, version).setFile(artifactFile);
+        Artifact artifact = new DefaultArtifact(groupId, artifactId, classifier, type, version).setFile(artifactFile);
         DeployRequest deployRequest = new DeployRequest().addArtifact(artifact);
+
+        if (pomFile != null) {
+            Artifact pomArtifact = new DefaultArtifact(groupId, artifactId, classifier, "pom", version).setFile(pomFile);
+            deployRequest.addArtifact(pomArtifact);
+        }
 
         deployRequest.setRepository(remoteRepository);
 

--- a/src/main/java/sp/sd/nexusartifactuploader/Utils.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/Utils.java
@@ -19,7 +19,7 @@ public final class Utils {
                                          String ResolvedGroupId, String ResolvedArtifactId, String ResolvedVersion,
                                          String ResolvedRepository, String ResolvedType,
                                          String ResolvedClassifier, String ResolvedProtocol,
-                                         String ResolvedNexusVersion) throws IOException {
+                                         String ResolvedNexusVersion, File pomFile) throws IOException {
         Boolean result = false;
         if (Strings.isNullOrEmpty(ResolvedNexusUrl)) {
             Listener.getLogger().println("Url of the Nexus is empty. Please enter Nexus Url.");
@@ -33,6 +33,9 @@ public final class Utils {
             Listener.getLogger().println("Type: " + ResolvedType);
             Listener.getLogger().println("Version: " + ResolvedVersion);
             Listener.getLogger().println("File: " + artifactFile.getName());
+            if (pomFile != null) {
+                Listener.getLogger().println("Pom file: " + pomFile.getName());
+            }
             Listener.getLogger().println("Repository:" + ResolvedRepository);
             String repositoryPath = "/content/repositories/";
             if (ResolvedNexusVersion.contentEquals("nexus3")) {
@@ -41,8 +44,9 @@ public final class Utils {
             ArtifactRepositoryManager artifactRepositoryManager = new ArtifactRepositoryManager(ResolvedProtocol + "://"
                     + ResolvedNexusUrl + repositoryPath + ResolvedRepository, ResolvedNexusUser,
                     ResolvedNexusPassword, ResolvedRepository, Listener);
-            artifactRepositoryManager.upload(ResolvedGroupId, ResolvedArtifactId, ResolvedVersion,
-                    artifactFile, ResolvedType, ResolvedClassifier);
+
+            artifactRepositoryManager.upload(ResolvedGroupId, ResolvedArtifactId, ResolvedVersion, artifactFile, ResolvedType, ResolvedClassifier, pomFile);
+
             Listener.getLogger().println("Uploading artifact " + artifactFile.getName() + " completed.");
             result = true;
         } catch (Exception e) {

--- a/src/main/java/sp/sd/nexusartifactuploader/dsl/ArtifactJobDslContext.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/dsl/ArtifactJobDslContext.java
@@ -11,6 +11,7 @@ public class ArtifactJobDslContext implements Context {
     String type;
     String classifier;
     String file;
+    String pomFile;
 
     void artifactId(String artifactId) {
         this.artifactId = artifactId;
@@ -28,4 +29,7 @@ public class ArtifactJobDslContext implements Context {
         this.file = file;
     }
 
+    public String pomFile() {
+        return pomFile;
+    }
 }

--- a/src/main/java/sp/sd/nexusartifactuploader/dsl/NexusArtifactUploaderJobDslContext.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/dsl/NexusArtifactUploaderJobDslContext.java
@@ -55,7 +55,7 @@ public class NexusArtifactUploaderJobDslContext implements Context {
     void artifact(@DslContext(ArtifactJobDslContext.class) Closure artifactClosure) {
         ArtifactJobDslContext context = new ArtifactJobDslContext();
         executeInContext(artifactClosure, context);
-        Artifact artifact = new Artifact(context.artifactId, context.type, context.classifier, context.file);
+        Artifact artifact = new Artifact(context.artifactId, context.type, context.classifier, context.file, context.pomFile);
         artifactList.add(artifact);
     }
 }

--- a/src/main/java/sp/sd/nexusartifactuploader/dsl/NexusArtifactUploaderJobDslExtension.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/dsl/NexusArtifactUploaderJobDslExtension.java
@@ -30,6 +30,7 @@ import sp.sd.nexusartifactuploader.NexusArtifactUploader;
                 type('jar')
                 classifier('debug')
                 file('nexus-artifact-uploader.jar')
+                pomFile('pom.xml')
             }
             artifact {
                 artifactId('nexus-artifact-uploader')

--- a/src/main/resources/sp/sd/nexusartifactuploader/Artifact/config.jelly
+++ b/src/main/resources/sp/sd/nexusartifactuploader/Artifact/config.jelly
@@ -14,6 +14,9 @@
         <f:entry title="File" field="file">
             <f:textbox/>
         </f:entry>
+        <f:entry title="Pom File" field="pomFile">
+            <f:textbox/>
+        </f:entry>
         <f:entry>
             <div align="right">
                 <f:repeatableDeleteButton/>

--- a/src/main/resources/sp/sd/nexusartifactuploader/Artifact/help-pomFile.html
+++ b/src/main/resources/sp/sd/nexusartifactuploader/Artifact/help-pomFile.html
@@ -1,0 +1,3 @@
+<div>File path in the workspace. ex:<i>${WORKSPACE}/&lt;module&gt;/pom.xml</i>.  Adding the pom file uploads the pom.xml to Nexus thereby given dependency information when the artifact is used.
+    In multi-module maven projects, if variables are used for version numbers then you should create a separate artifact.  This artifact's <code>ArtifactId</code> should match the artifactId in the root pom.xml.
+    The <code>Type</code> set to <i>pom</i> and the <code>File</code> (not Pom File) pointing to the root pom.xml</div>

--- a/src/test/java/sp/sd/nexusartifactuploader/ArtifactTest.java
+++ b/src/test/java/sp/sd/nexusartifactuploader/ArtifactTest.java
@@ -15,7 +15,7 @@ public class ArtifactTest {
     @WithoutJenkins
     public void testDefaults() {
         Artifact artifact = new Artifact("nexus-artifact-uploader", "jpi", "debug",
-                "target/nexus-artifact-uploader.jpi");
+                "target/nexus-artifact-uploader.jpi", "pom.xml");
         assertEquals("nexus-artifact-uploader", artifact.getArtifactId());
         assertEquals("jpi", artifact.getType());
         assertEquals("debug", artifact.getClassifier());
@@ -26,7 +26,7 @@ public class ArtifactTest {
     @WithoutJenkins
     public void testFileNameTrimming() {
         Artifact artifact = new Artifact("nexus-artifact-uploader", "jpi", "debug",
-                "target/nexus-artifact-uploader.jpi ");
+                "target/nexus-artifact-uploader.jpi ", "pom.xml");
         assertEquals("target/nexus-artifact-uploader.jpi", artifact.getFile());
     }
 }


### PR DESCRIPTION
… Nexus artifacts.

This is in relation to bug listed [here](https://issues.jenkins-ci.org/browse/JENKINS-51195)

I came across a similar issue when building a project in jenkins when an artifact couldn't find the pom file and showing the following message in the build output.

`The pom for <artifact> is missing, no dependency information available`