### PR TITLE
[JENKINS-69994] Refresh plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.4</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+### Release 2.10 (13 August 2017)
+
+- \[JENKINS-46109\] Fixed 404 errors in configure page with Dropdown controls.
+- \[JENKINS-45995\] Trim artifact filename when spaces added by mistake.
+
+### Release 2.9 (13 December 2016)
+
+- \[JENKINS-39594\] Fixed frequent, intermittent "Failed to deploy artifacts".
+
+### Release 2.8 (21 November 2016)
+
+- \[JENKINS-38950\] Added support for uploading multiple artifacts.
+
+### Release 2.7 (15 October 2016)
+
+- \[FIXED JENKINS-38918\] Build is not failing in pipeline on failed upload.
+
+### Release 2.6 (08 October 2016)
+
+- \[JENKINS-37960\] Added support for Nexus-3 version to upload artifacts.
+
+### Release 2.5 (30 September 2016)
+
+- Added DSL support and above is the example to use this plugin.
+
+### Release 2.4 (20 August 2016)
+
+- Added support for entering classifier and type.
+- \[JENKINS-37536\] - Fixed null pointer exception when passing folder level credentials.
+
+### Release 2.3 (28 July 2016)
+
+- Upgraded Credentials plugin to 2.1.0.
+
+### Release 2.2 (24 May 2016)
+
+- Added support for Jenkins Pipeline.
+- Added "nexusArtifactUploader" as pipeline step.
+
+### Release 2.1.2 (06 April 2016)
+
+- Fixed protocol issue when configured HTTPS it resets to HTTP
+
+### Release 2.1.1 (05 April 2016)
+
+- Added empty option to Jenkins Credentials
+
+### Release 2.1 (03 April 2016)
+
+- Added Jenkins Credentials to pass username and password
+
+### Release 2.0 (13 March 2016)
+
+- Removing the dependency with TokenMacro for resolving environment variables used Jenkins method to resolve.
+- Added help text for the important fields.
+- Added error message from server when failed to upload to nexus.
+- Added uploaded artifact link in side bar.
+- Changed name of the plugin from "Upload artifacts to nexus" to
+"Nexus Artifact Uploader"
+
+### Release 1.1 (07 March 2016)
+
+- Fixed Uploading files from Slave machines.
+- Fixed validation issue with Nexus Url
+
+### Release 1.0 (06 March 2016)
+
+- First public release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nexus-artifact-uploader
+# Nexus Artifact Uploader
 
 This plugin goal is to upload artifacts generated from non-maven projects to Nexus
 
@@ -6,8 +6,9 @@ This plugin now supports Nexus-2.x & Nexus-3.x.
 
 Uploading snapshots is not supported by this plugin.
 
-# Job DSL example
+### Job DSL example
 
+```groovy
     freeStyleJob('NexusArtifactUploaderJob') {
         steps {
           nexusArtifactUploader {
@@ -33,9 +34,11 @@ Uploading snapshots is not supported by this plugin.
           }
         }
     }
+```
 
 # Jenkins pipeline example
 
+```groovy
     nexusArtifactUploader(
         nexusVersion: 'nexus3',
         protocol: 'http',
@@ -51,3 +54,4 @@ Uploading snapshots is not supported by this plugin.
              type: 'jar']
         ]
      )
+```

--- a/pom.xml
+++ b/pom.xml
@@ -5,27 +5,29 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.15</version>
+        <version>4.49</version>
         <relativePath />
     </parent>
     <groupId>sp.sd</groupId>
     <artifactId>nexus-artifact-uploader</artifactId>
-    <version>2.14-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>1.651.3</jenkins.version>
-        <java.level>7</java.level>
+        <revision>2.14</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <jenkins.version>2.319.3</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
     <name>Nexus Artifact Uploader</name>
     <description>Nexus Artifact Uploader is to upload artifact to Nexus Repo</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Nexus+Artifact+Uploader</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
+            <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
 
@@ -37,10 +39,10 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
     <repositories>
         <repository>
@@ -54,21 +56,45 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.319.x</artifactId>
+                <version>1654.vcb_69d035fa_20</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-provider-api</artifactId>
+                <version>2.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>3.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-httpclient3-api</artifactId>
+            <version>3.1-3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.41</version>
+            <version>1.81</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -95,6 +121,13 @@
             <groupId>org.sonatype.aether</groupId>
             <artifactId>aether-connector-asynchttpclient</artifactId>
             <version>1.13.1</version>
+            <exclusions>
+                <exclusion>
+                    <!-- Provided by Jenkins core -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.sonatype.aether</groupId>
@@ -112,9 +145,8 @@
             <version>3.0.3</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sonatype.aether</groupId>
@@ -135,15 +167,6 @@
     </dependencies>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>InjectedTest.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>

--- a/src/main/java/sp/sd/nexusartifactuploader/Artifact.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/Artifact.java
@@ -8,7 +8,7 @@ import hudson.util.FormValidation;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.CheckReturnValue;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import java.io.Serializable;
 
 /**

--- a/src/main/java/sp/sd/nexusartifactuploader/NexusArtifactUploader.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/NexusArtifactUploader.java
@@ -22,8 +22,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.jenkinsci.remoting.RoleChecker;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;

--- a/src/main/java/sp/sd/nexusartifactuploader/steps/NexusArtifactUploaderStep.java
+++ b/src/main/java/sp/sd/nexusartifactuploader/steps/NexusArtifactUploaderStep.java
@@ -13,8 +13,8 @@ import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.google.common.base.Strings;
 import hudson.*;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.inject.Inject;
 
 import hudson.model.Item;


### PR DESCRIPTION
See [JENKINS-69994](https://issues.jenkins.io/browse/JENKINS-69994). This plugin currently consumes the deprecated Commons HttpClient 3.x API via Jenkins core. In https://github.com/jenkinsci/jenkins/pull/7312 we plan to remove this library from Jenkins core. To ensure this plugin continues to work, this PR prepares the plugin for https://github.com/jenkinsci/jenkins/pull/7312 by adding a dependency on the [Commons HttpClient 3.x API plugin](https://plugins.jenkins.io/commons-httpclient3-api/). While we were here, we refreshed the build toolchain and dependencies to recent versions. CC @pskumar448