### PR TITLE
Remove commons-httpclient3-api plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: 'linux', jdk: '8' ],
   [ platform: 'linux', jdk: '11' ],
-  [ platform: 'windows', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <revision>2.15</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.319.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <maven.version>3.8.6</maven.version>
         <wagon.version>3.5.2</wagon.version>
@@ -62,8 +62,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.319.x</artifactId>
-                <version>1654.vcb_69d035fa_20</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2977.vdf61ecb_fb_e2d</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -87,11 +87,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>commons-httpclient3-api</artifactId>
-            <version>3.1-3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Remove the deprecated / outdated httpclient3-api plugin. On further investigation, httpclient3 is not required in the first place.

### Testing done
Validated via `mvn verify`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
